### PR TITLE
bump!: Bump django to 3.2

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/base.txt
+++ b/{{cookiecutter.repo_name}}/requirements/base.txt
@@ -1,45 +1,45 @@
 # Django 
-Django==2.2.16
-django-kn-defaults==0.2.9
-djvue==0.1.0
-sentry-sdk==0.17.3
-elastic-apm==5.8.1
+Django>=3.2,<3.3
+django-kn-defaults==0.3.1
+djvue==0.2.1
+sentry-sdk==1.5.1
+elastic-apm==6.7.2
 
 {% if cookiecutter.cms_package == "django-cms" %}
 # Django CMS + dependencies
 appdirs==1.4.4
-django-appconf==1.0.4
-django-cms==3.7.3
+django-appconf==1.0.5
+django-cms==3.9.0
 djangocms-text-ckeditor==3.9.1
 {% endif %}
 
 {% if cookiecutter.cms_package == "wagtail" %}
-wagtail==2.10.1
+wagtail==2.15.1
 {% endif %}
 
 {% if cookiecutter.django_filer == "y" or cookiecutter.django_filer == "Y" %}
 # Django filer plugin
-django-filer==1.7.1
-easy-thumbnails==2.7
+django-filer==2.1.2
+easy-thumbnails==2.8
 {% endif %}
 
 # for windows please add following lib before installing compressor
-# rcssmin==1.0.6 --install-option="--without-c-extensions"
-django-compressor==2.4
+# rcssmin==1.1.0 --install-option="--without-c-extensions"
+django-compressor==3.1
 
 {% if cookiecutter.redis == "y" or cookiecutter.redis == "Y" %}
-django-redis==4.12.1
-django-rq==2.3.2
-redis==3.5.3
+django-redis==5.2.0
+django-rq==2.5.1
+redis==4.1.0
 {% endif %}
-djangorestframework==3.11.1
-django-environ==0.4.5
+djangorestframework==3.13.1
+django-environ==0.8.1
 
 {% if cookiecutter.django_cors == "y" or cookiecutter.django_cors == "Y" %}
-django-cors-headers==3.4.0
+django-cors-headers==3.10.1
 {% endif %}
 
 {% if cookiecutter.s3 == "y" or cookiecutter.s3 == "Y" %}
-django-storages==1.9.1
-boto3==1.14.11
+django-storages==1.12.3
+boto3==1.20.27
 {% endif %}

--- a/{{cookiecutter.repo_name}}/requirements/development.txt
+++ b/{{cookiecutter.repo_name}}/requirements/development.txt
@@ -2,13 +2,13 @@
 
 -r base.txt
 
-django-debug-toolbar==3.1.1
-pytest-django==3.10.0
-mixer==6.1.3
-pytest-cov==2.10.1
-flake8==3.8.4
-flake8-isort==4.0.0
-black==19.10b0
-pylint-django==2.3.0
-pre-commit==2.7.1
-factory-boy==3.1.0
+django-debug-toolbar==3.2.4
+pytest-django==4.5.2
+mixer==7.2.0
+pytest-cov==3.0.0
+flake8==4.0.1
+flake8-isort==4.1.1
+black==21.12b0
+pylint-django==2.5.0
+pre-commit==2.16.0
+factory-boy==3.2.1


### PR DESCRIPTION
Upgrade cookiecutter template to Django 3.2 and upgrade the requirements accordingly.